### PR TITLE
Export OIDC types and middleware from Keycloak package

### DIFF
--- a/packages/auth/keycloak/src/lib/index.ts
+++ b/packages/auth/keycloak/src/lib/index.ts
@@ -1,1 +1,8 @@
 // Reexport your entry components here
+import {type OidcConfig} from "./types.ts";
+import {OidcMiddleware} from "./middleware.ts";
+
+export {
+    type OidcConfig,
+    OidcMiddleware
+};


### PR DESCRIPTION
Closes #14

## Summary by Sourcery

New Features:
- Expose OidcConfig type and OidcMiddleware from the Keycloak package entry point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated public API exports for Keycloak authentication module to improve accessibility for developers integrating authentication functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->