### PR TITLE
Remove unsupported `priority` property from cookie serialization

### DIFF
--- a/packages/session/src/lib/session.ts
+++ b/packages/session/src/lib/session.ts
@@ -151,7 +151,6 @@ const handleSessionMiddlewareInternal: InternalMiddlewareHandle = async (
 		secure: secure,
 		sameSite: 'strict',
 		httpOnly: true,
-		priority: 'high'
 	});
 
 	// we have to redirect to write a cookie


### PR DESCRIPTION
Closes #26

## Summary by Sourcery

Bug Fixes:
- Avoid setting an unsupported `priority` attribute when serializing session cookies to ensure compatibility with cookie handling libraries and runtimes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined session cookie configuration by removing a non-essential attribute. All security measures and behavioral attributes remain intact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->