### PR TITLE
Update release workflow trigger to activate on release events only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: "Release"
 on:
-  push:
   release:
     types:
       - published


### PR DESCRIPTION
Closes #28

## Summary by Sourcery

CI:
- Update the GitHub Actions release workflow trigger to listen solely for published release events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow trigger configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->